### PR TITLE
Fix image issue for readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ them needed for solving specific problems.
 evaluating their effectiveness based on industry standards.
 
 ##### Table 2: Mapping of CO, PO, Blooms, KP and CEP
-![The Table Markdown](./image/Table%202.PNG)
+![The Table Markdown](./Image/Table%202.png)


### PR DESCRIPTION
# Issue 
Linux is case sensitive. As image directory starts with capital **I** , so it should also use Image in readme file while loading image from directory. 

`./image/Table%202.PNG : don't work`
`./Image/Table%202.png: will work`

**In windows machine I and i are both same. But in linux it is different. Because github.com is hosted in linux environment**
